### PR TITLE
Starfleck patch 5

### DIFF
--- a/Data/CubeBlocks_Drill.sbc
+++ b/Data/CubeBlocks_Drill.sbc
@@ -1,7 +1,159 @@
 <?xml version="1.0"?>
 <Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <CubeBlocks>
-        <!--        Tier 2-->
+        <!-- Vanilla adjustment -->
+        <Definition xsi:type="MyObjectBuilder_ShipDrillDefinition">
+            <Id>
+                <TypeId>Drill</TypeId>
+                <SubtypeId>SmallBlockDrill</SubtypeId>
+            </Id>
+            <DisplayName>DisplayName_Block_Drill</DisplayName>
+            <Icon>Textures\GUI\Icons\Cubes\drill.dds</Icon>
+            <Description>Description_Drill</Description>
+            <CubeSize>Small</CubeSize>
+            <GuiVisible>false</GuiVisible>
+            <BlockTopology>TriangleMesh</BlockTopology>
+            <Size x="3" y="3" z="6" />
+            <ModelOffset x="0" y="0" z="0" />
+            <Model>Models\Cubes\Small\driller.mwm</Model>
+            <PlaceDecals>false</PlaceDecals>
+            <UseModelIntersection>true</UseModelIntersection>
+            <Components>
+                <Component Subtype="SteelPlate" Count="20" />
+                <Component Subtype="Construction" Count="30" />
+                <Component Subtype="LargeTube" Count="4" />
+                <Component Subtype="Motor" Count="1" />
+                <Component Subtype="Computer" Count="1" />
+                <Component Subtype="SteelPlate" Count="12" />
+            </Components>
+            <CriticalComponent Subtype="Computer" Index="0" />
+            <Center x="1" y="1" z="5" />
+            <MountPoints>
+                <MountPoint Side="Back" StartX="0" StartY="1" EndX="3" EndY="2" Default="true" />
+                <MountPoint Side="Right" StartX="0" StartY="1" EndX="2" EndY="2" />
+                <MountPoint Side="Left" StartX="4" StartY="1" EndX="6" EndY="2" />
+            </MountPoints>
+            <BuildProgressModels>
+                <Model BuildPercentUpperBound="0.50" File="Models\Cubes\Small\DrillerConstruction_1.mwm" />
+                <Model BuildPercentUpperBound="1.00" File="Models\Cubes\Small\DrillerConstruction_2.mwm" />
+            </BuildProgressModels>
+            <VoxelPlacement>
+                <!--Possible settings Both,InVoxel,OutsideVoxel,Volumetric. If volumetric set than MaxAllowed and MinAllowed will be used.-->
+                <StaticMode>
+                    <PlacementMode>OutsideVoxel</PlacementMode>
+                    <MaxAllowed>0.2</MaxAllowed>
+                    <MinAllowed>0</MinAllowed>
+                </StaticMode>
+                <DynamicMode>
+                    <PlacementMode>OutsideVoxel</PlacementMode>
+                    <MaxAllowed>0.2</MaxAllowed>
+                    <MinAllowed>0.01</MinAllowed>
+                </DynamicMode>
+            </VoxelPlacement>
+            <BlockPairName>Drill</BlockPairName>
+            <MirroringY>Z</MirroringY>
+            <MirroringZ>Y</MirroringZ>
+            <EdgeType>Light</EdgeType>
+            <BuildTimeSeconds>20</BuildTimeSeconds>
+
+            <ResourceSinkGroup>Defense</ResourceSinkGroup>
+            <SensorRadius>1.56</SensorRadius>
+            <SensorOffset>0.8</SensorOffset>
+            <CutOutRadius>1.56</CutOutRadius>
+            <CutOutOffset>0.6</CutOutOffset>
+            <ParticleOffset>
+                <X>0</X>
+                <Y>0</Y>
+                <Z>-1.45</Z>
+            </ParticleOffset>
+
+            <DeformationRatio>0.2</DeformationRatio>
+            <UsesDeformation>false</UsesDeformation>
+            <DamageEffectName>Damage_HeavyMech_Damaged</DamageEffectName>
+            <DamagedSound>ParticleHeavyMech</DamagedSound>
+            <PrimarySound>ToolShipDrillIdle</PrimarySound>
+            <DestroyEffect>BlockDestroyedExplosion_Small</DestroyEffect>
+            <DestroySound>WepSmallWarheadExpl</DestroySound>
+            <PCU>190</PCU>
+        </Definition>
+        <Definition xsi:type="MyObjectBuilder_ShipDrillDefinition">
+            <Id>
+                <TypeId>Drill</TypeId>
+                <SubtypeId>LargeBlockDrill</SubtypeId>
+            </Id>
+            <DisplayName>DisplayName_Block_Drill</DisplayName>
+            <Icon>Textures\GUI\Icons\Cubes\drill.dds</Icon>
+            <Description>Description_Drill</Description>
+            <CubeSize>Large</CubeSize>
+            <GuiVisible>false</GuiVisible>
+            <BlockTopology>TriangleMesh</BlockTopology>
+            <Size x="1" y="1" z="3" />
+            <ModelOffset x="0" y="0" z="0" />
+            <Model>Models\Cubes\Large\drill.mwm</Model>
+            <PlaceDecals>false</PlaceDecals>
+            <UseModelIntersection>true</UseModelIntersection>
+            <UsesDeformation>false</UsesDeformation>
+            <Components>
+                <Component Subtype="SteelPlate" Count="180" />
+                <Component Subtype="Construction" Count="40" />
+                <Component Subtype="LargeTube" Count="12" />
+                <Component Subtype="Motor" Count="5" />
+                <Component Subtype="Computer" Count="5" />
+                <Component Subtype="SteelPlate" Count="120" />
+            </Components>
+            <CriticalComponent Subtype="Computer" Index="0" />
+            <MountPoints>
+                <MountPoint Side="Back" StartX="0" StartY="0" EndX="1" EndY="1" Default="true" />
+                <MountPoint Side="Top" StartX="0" StartY="0" EndX="1" EndY="1" />
+                <MountPoint Side="Bottom" StartX="0" StartY="2" EndX="1" EndY="3" />
+                <MountPoint Side="Right" StartX="0" StartY="0" EndX="1" EndY="1" />
+                <MountPoint Side="Left" StartX="2" StartY="0" EndX="3" EndY="1" />
+            </MountPoints>
+            <BuildProgressModels>
+                <Model BuildPercentUpperBound="0.33" File="Models\Cubes\Large\DrillConstruction_1.mwm" />
+                <Model BuildPercentUpperBound="0.66" File="Models\Cubes\Large\DrillConstruction_2.mwm" />
+                <Model BuildPercentUpperBound="1.00" File="Models\Cubes\Large\DrillConstruction_3.mwm" />
+            </BuildProgressModels>
+            <VoxelPlacement>
+                <!--Possible settings Both,InVoxel,OutsideVoxel,Volumetric. If volumetric set than MaxAllowed and MinAllowed will be used.-->
+                <StaticMode>
+                    <PlacementMode>OutsideVoxel</PlacementMode>
+                    <MaxAllowed>0.2</MaxAllowed>
+                    <MinAllowed>0</MinAllowed>
+                </StaticMode>
+                <DynamicMode>
+                    <PlacementMode>OutsideVoxel</PlacementMode>
+                    <MaxAllowed>0.2</MaxAllowed>
+                    <MinAllowed>0.01</MinAllowed>
+                </DynamicMode>
+            </VoxelPlacement>
+            <BlockPairName>Drill</BlockPairName>
+            <MirroringY>Z</MirroringY>
+            <MirroringZ>Y</MirroringZ>
+            <EdgeType>Light</EdgeType>
+            <BuildTimeSeconds>30</BuildTimeSeconds>
+            <Center x="0" y="0" z="2" />
+
+            <ResourceSinkGroup>Defense</ResourceSinkGroup>
+            <SensorRadius>2.27</SensorRadius>
+            <SensorOffset>2.8</SensorOffset>
+            <CutOutRadius>2.27</CutOutRadius>
+            <CutOutOffset>2.8</CutOutOffset>
+            <ParticleOffset>
+                <X>0</X>
+                <Y>0</Y>
+                <Z>-3.6</Z>
+            </ParticleOffset>
+
+            <DeformationRatio>0.2</DeformationRatio>
+            <DamageEffectName>Damage_HeavyMech_Damaged</DamageEffectName>
+            <DamagedSound>ParticleHeavyMech</DamagedSound>
+            <PrimarySound>ToolShipDrillIdle</PrimarySound>
+            <DestroyEffect>BlockDestroyedExplosion_Large</DestroyEffect>
+            <DestroySound>WepSmallWarheadExpl</DestroySound>
+            <PCU>190</PCU>
+        </Definition>
+		<!--        Tier 2-->
         <!--Small Drill-->
         <Definition xsi:type="MyObjectBuilder_ShipDrillDefinition">
             <Id>
@@ -59,9 +211,9 @@
             <BuildTimeSeconds>30</BuildTimeSeconds>
 
             <ResourceSinkGroup>Defense</ResourceSinkGroup>
-            <SensorRadius>2.6</SensorRadius> <!-- Original mod was braindeadMath, fixed it with actual geometry. Effective 4x circlecut-area for plunge drilling. -->
+            <SensorRadius>3.1</SensorRadius>
             <SensorOffset>0.8</SensorOffset>
-            <CutOutRadius>2.6</CutOutRadius>
+            <CutOutRadius>3.1</CutOutRadius>
             <CutOutOffset>0.6</CutOutOffset>
             <ParticleOffset>
                 <X>0</X>
@@ -140,9 +292,9 @@
             <Center x="0" y="0" z="2"/>
 
             <ResourceSinkGroup>Defense</ResourceSinkGroup>
-            <SensorRadius>3.8</SensorRadius>
+            <SensorRadius>4.54</SensorRadius>
             <SensorOffset>2.8</SensorOffset>
-            <CutOutRadius>3.8</CutOutRadius>
+            <CutOutRadius>4.54</CutOutRadius>
             <CutOutOffset>2.8</CutOutOffset>
             <ParticleOffset>
                 <X>0</X>
@@ -218,9 +370,9 @@
             <BuildTimeSeconds>45</BuildTimeSeconds>
 
             <ResourceSinkGroup>Defense</ResourceSinkGroup>
-            <SensorRadius>3.2</SensorRadius>
+            <SensorRadius>3.8</SensorRadius>
             <SensorOffset>0.8</SensorOffset>
-            <CutOutRadius>3.2</CutOutRadius>
+            <CutOutRadius>3.8</CutOutRadius>
             <CutOutOffset>0.6</CutOutOffset>
             <ParticleOffset>
                 <X>0</X>
@@ -299,9 +451,9 @@
             <Center x="0" y="0" z="2"/>
 
             <ResourceSinkGroup>Defense</ResourceSinkGroup>
-            <SensorRadius>4.7</SensorRadius>
+            <SensorRadius>5.56</SensorRadius>
             <SensorOffset>2.8</SensorOffset>
-            <CutOutRadius>4.7</CutOutRadius>
+            <CutOutRadius>5.56</CutOutRadius>
             <CutOutOffset>2.8</CutOutOffset>
             <ParticleOffset>
                 <X>0</X>
@@ -377,9 +529,9 @@
             <BuildTimeSeconds>68</BuildTimeSeconds>
 
             <ResourceSinkGroup>Defense</ResourceSinkGroup>
-            <SensorRadius>3.7</SensorRadius>
+            <SensorRadius>4.39</SensorRadius>
             <SensorOffset>0.8</SensorOffset>
-            <CutOutRadius>3.7</CutOutRadius>
+            <CutOutRadius>4.39</CutOutRadius>
             <CutOutOffset>0.6</CutOutOffset>
             <ParticleOffset>
                 <X>0</X>
@@ -458,9 +610,9 @@
             <Center x="0" y="0" z="2"/>
 
             <ResourceSinkGroup>Defense</ResourceSinkGroup>
-            <SensorRadius>5.4</SensorRadius> <!-- Biggest drill, effective 8x cutting circle, even more in volume. Actually a decrease from SW4 iteration, so we can go back and adjust vanilla if complaining becomes a problem -->
+            <SensorRadius>6.42</SensorRadius> <!-- Biggest drill, effective 8x cutting circle, for PAM users. Revert to 4.0 -->
             <SensorOffset>2.8</SensorOffset>
-            <CutOutRadius>5.4</CutOutRadius>
+            <CutOutRadius>6.42</CutOutRadius>
             <CutOutOffset>2.8</CutOutOffset>
             <ParticleOffset>
                 <X>0</X>

--- a/Data/CubeBlocks_Grinder.sbc
+++ b/Data/CubeBlocks_Grinder.sbc
@@ -68,7 +68,7 @@
             <Flare></Flare>
             <DestroyEffect>BlockDestroyedExplosion_Small</DestroyEffect>
             <DestroySound>WepSmallWarheadExpl</DestroySound>
-            <SensorRadius>3.8</SensorRadius>
+            <SensorRadius>5.68</SensorRadius>
             <PCU>100</PCU>
             <IsAirTight>false</IsAirTight>
 
@@ -137,7 +137,7 @@
             <Flare></Flare>
             <DestroyEffect>BlockDestroyedExplosion_Large</DestroyEffect>
             <DestroySound>WepSmallWarheadExpl</DestroySound>
-            <SensorRadius>5.4</SensorRadius>
+            <SensorRadius>7.58</SensorRadius>
             <PCU>100</PCU>
 
         </Definition>
@@ -209,7 +209,7 @@
             <Flare></Flare>
             <DestroyEffect>BlockDestroyedExplosion_Small</DestroyEffect>
             <DestroySound>WepSmallWarheadExpl</DestroySound>
-            <SensorRadius>4.6</SensorRadius>
+            <SensorRadius>6.96</SensorRadius>
             <PCU>100</PCU>
             <IsAirTight>false</IsAirTight>
 
@@ -278,7 +278,7 @@
             <Flare></Flare>
             <DestroyEffect>BlockDestroyedExplosion_Large</DestroyEffect>
             <DestroySound>WepSmallWarheadExpl</DestroySound>
-            <SensorRadius>6.6</SensorRadius>
+            <SensorRadius>9.27</SensorRadius>
             <PCU>100</PCU>
 
         </Definition>
@@ -350,7 +350,7 @@
             <Flare></Flare>
             <DestroyEffect>BlockDestroyedExplosion_Small</DestroyEffect>
             <DestroySound>WepSmallWarheadExpl</DestroySound>
-            <SensorRadius>5.4</SensorRadius>
+            <SensorRadius>8.04</SensorRadius>
             <PCU>100</PCU>
             <IsAirTight>false</IsAirTight>
 
@@ -419,7 +419,7 @@
             <Flare></Flare>
             <DestroyEffect>BlockDestroyedExplosion_Large</DestroyEffect>
             <DestroySound>WepSmallWarheadExpl</DestroySound>
-            <SensorRadius>7.6</SensorRadius>
+            <SensorRadius>10.72</SensorRadius>
             <PCU>100</PCU>
 
         </Definition>


### PR DESCRIPTION
In order to maintain 1x-4x-6x-8x parity I've added vanilla drills to the list *(also making drills+ mod obsolete), while reverting the Elite drills, both sizes, to their 4.0 drill radius. Also did the same with grinders although I chose not to add vanilla grinders, because of the already high tech cost of those blocks, it seemed unnecessary.